### PR TITLE
Added update of the VirtualBox addin in the Vagrant file. 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,4 +7,9 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "udacity/ud381"
   config.vm.network :forwarded_port, guest: 5000, host: 5000
+  if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = false
+    config.vbguest.no_install = true
+    config.vbguest.no_remote = true
+  end
 end


### PR DESCRIPTION
This resolves a bug that caused the Vagrant shared directory not to be loaded with vagrant 1.8.5 and VirtualBox Version 5.0.10 r104061 on Mac OS X10.11.6. Note that this fix introduces a dependency on the vagrant plugin https://github.com/dotless-de/vagrant-vbguest.